### PR TITLE
Fix multicore config build errors

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -110,6 +110,10 @@
 #define configUSE_CORE_AFFINITY                 1
 #endif
 
+#if ( configNUMBER_OF_CORES > 1 )
+#define configUSE_MINIMAL_IDLE_HOOK             0
+#endif
+
 /* RP2040 specific */
 #define configSUPPORT_PICO_SYNC_INTEROP         1
 #define configSUPPORT_PICO_TIME_INTEROP         1

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -107,11 +107,12 @@
 #define configNUMBER_OF_CORES                   1
 #define configTICK_CORE                         0
 #define configRUN_MULTIPLE_PRIORITIES           1
-#define configUSE_CORE_AFFINITY                 1
 #endif
 
 #if ( configNUMBER_OF_CORES > 1 )
+#define configUSE_CORE_AFFINITY                 1
 #define configUSE_MINIMAL_IDLE_HOOK             0
+#define configUSE_PASSIVE_IDLE_HOOK             0
 #endif
 
 /* RP2040 specific */


### PR DESCRIPTION
I would like to add FreeRTOS SMP support to the mainline OpenOCD, which we already have in our Espressif branch. I need one more architecture for testing. However, when I load Example2 from this link https://learnembeddedsystems.co.uk/freertos-smp-tutorial, I cannot see core 1 in the printed logs, and TaskB is also missing
```
A 0
C 0
D 0
A 0
C 0
D 0
A 0
C 0
D 0
A 0
C 0
D 0
A 0
```

